### PR TITLE
Fix error while fetching closest mirror url for Apache Solr.

### DIFF
--- a/roles/jiv_e.solr/tasks/install-solr.yml
+++ b/roles/jiv_e.solr/tasks/install-solr.yml
@@ -10,7 +10,7 @@
   apt: name=curl state=present
 
 - name: Get the closest mirror for Apache Solr
-  shell: curl -s http://www.apache.org/dyn/closer.cgi/lucene/solr | sed -n '/id="http"/,/id="backup"/p' | sed -nr 's/.*href=\"(.*)\".*/\1/p'
+  shell: curl -s http://www.apache.org/dyn/closer.cgi/lucene/solr | sed -n '/id="http"/,/id="backup"/p' | sed -nr 's/.*href=\"(.*)\".*/\1/p' | sed -n 1p
   register: jiv_solr__closestMirror
   changed_when: false
 


### PR DESCRIPTION
Fix matching pattern for the closest mirror for Apache Solr due to html page structure chengaes.
