### PR TITLE
Update search_api_solr to 7.x-1.6

### DIFF
--- a/roles/jiv_e.solr/defaults/main.yml
+++ b/roles/jiv_e.solr/defaults/main.yml
@@ -3,15 +3,15 @@ jiv_solr__version: 4.7.2
 
 ## search_api_solr Drupal module ##
 #Version
-jiv_solr__searchApiSolrVersion: 7.x-1.5
+jiv_solr__searchApiSolrVersion: 7.x-1.6
 jiv_solr__searchApiSolrId: search_api_solr-{{ jiv_solr__searchApiSolrVersion }}
-#Path to the Solr configuration 
+#Path to the Solr configuration
 jiv_solr__searchApiSolrConfPath: "{{ jiv_solr__searchApiSolrId }}/solr-conf/4.x"
 ## apachesolr Drupal module ##
 #Version
 jiv_solr__apachesolrVersion: 7.x-1.x-dev
 jiv_solr__apachesolrId: apachesolr-{{ jiv_solr__apachesolrVersion }}
-#Path to the Solr configuration 
+#Path to the Solr configuration
 jiv_solr__apachesolrConfPath: "{{ jiv_solr__apachesolrId }}/solr-conf/solr-4.x"
 
 # Linux user and group name
@@ -23,7 +23,7 @@ jiv_solr__downloadPath: "{{ jiv_solr__version }}/solr-{{ jiv_solr__version }}.tg
 jiv_solr__tempPath: /tmp/ansible_solr
 jiv_solr__saveTarPath: "{{ jiv_solr__tempPath }}/solr-{{ jiv_solr__version }}.tgz"
 jiv_solr__installPath: /opt/solr
-jiv_solr__multicoreRoot: cores 
+jiv_solr__multicoreRoot: cores
 jiv_solr__cores:
   - { name: core1, coreType: default, keepChanges: no }
   - { name: core2, coreType: drupal_apachesolr, keepChanges: no }
@@ -32,8 +32,8 @@ jiv_solr__cores:
 # Uninstalling
 # You can easily override these on the command line.
 # E.g. ansible-playbook -i hosts play.yml -e jiv_solr__uninstall=true -e jiv_solr__uninstallDependencies=true
-jiv_solr__uninstall: no 
-jiv_solr__uninstallDependencies: no 
+jiv_solr__uninstall: no
+jiv_solr__uninstallDependencies: no
 
 # Not yet implemented
 jiv_solr__passwordProtection: no
@@ -45,5 +45,5 @@ jiv_solr__passwordProtection: no
 # By including your own computers IP you can use the web interface.
 
 #jiv_solr__allowedHosts:
-#  - xxx.xx.xxx.xx 
-#  - xxx.xx.xxx.xx 
+#  - xxx.xx.xxx.xx
+#  - xxx.xx.xxx.xx


### PR DESCRIPTION
    ASK: [jiv_e.solr | Extract search_api_solr Drupal module] ******************** 
    failed: [removed] => {"changed": true, "cmd": ["tar", "-x", "--overwrite", "-f", "/tmp/ansible_solr/search_api_solr-7.x-1.5.tar.gz", "-C", "/tmp/ansible_solr/search_api_solr-7.x-1.5", "--strip-components=1"], "delta": "0:00:00.002502", "end": "2015-03-30 23:00:57.789002", "rc": 2, "start": "2015-03-30 23:00:57.786500", "warnings": ["Consider using unarchive module rather than running tar"]}
    stderr: tar: This does not look like a tar archive

    gzip: stdin: not in gzip format
    tar: Child returned status 1
    tar: Error is not recoverable: exiting now

    FATAL: all hosts have already failed -- aborting


Looks like 7.x.1-5 is no longer available for download.