### PR TITLE
Make sed more robust when parse nearest mirror

### DIFF
--- a/roles/jiv_e.solr/tasks/install-solr.yml
+++ b/roles/jiv_e.solr/tasks/install-solr.yml
@@ -13,7 +13,7 @@
   apt: name=curl state=present
 
 - name: Get the closest mirror for Apache Solr
-  shell: curl -s http://www.apache.org/dyn/closer.cgi/lucene/solr | sed -n '/id="http"/,/id="backup"/p' | sed -nr 's/.*href=\"(.*)\".*/\1/p' | sed -n 1p
+  shell: curl -s http://www.apache.org/dyn/closer.cgi/lucene/solr | sed -n '/id="http"/,/id="backup"/p' | sed -nr 's/.*href=\"(.*)\".*/\1/p' | sed -n '2,${/https\?:\/\//p;q}'
   register: jiv_solr__closestMirror
   changed_when: false
 


### PR DESCRIPTION
It looks like the maintainers might have changed the HTML structure of the page so this new sed regex will look for the first occurrence of a string beginning with http:// or https:// instead of just the first string as it was before. Without this an HTML hash anchor is returned instead breaking the download path used in the next step of the provisioning process.
